### PR TITLE
Confirmação de exclusão de camada

### DIFF
--- a/config/dev.env.js
+++ b/config/dev.env.js
@@ -5,10 +5,10 @@ const prodEnv = require('./prod.env')
 module.exports = merge(prodEnv, {
   NODE_ENV: '"development"',
   // urlVGI: '"http://localhost:3001"',
-  urlVGI: '"http://localhost:8888"',
+  urlVGI: '"http://www.pauliceia.dpi.inpe.br/api/vgi"',
   // urlGeoserverPauliceia: '"http://localhost:9021/geoserver/pauliceia"',
-  urlGeoserverPauliceia: '"https://pauliceia.unifesp.brgeoserver/pauliceia"',
-  urlGeoserveOther: '"https://pauliceia.unifesp.br/geoserver/other"',
-  urlGeocoding: '"https://pauliceia.unifesp.br/api/geocoding"',
+  urlGeoserverPauliceia: '"http://www.pauliceia.dpi.inpe.br/geoserver/pauliceia"',
+  urlGeoserveOther: '"http://www.pauliceia.dpi.inpe.br/geoserver/other"',
+  urlGeocoding: '"http://www.pauliceia.dpi.inpe.br/api/geocoding"',
   keyCripto: '"keytest"'
 })

--- a/config/dev.env.js
+++ b/config/dev.env.js
@@ -5,10 +5,10 @@ const prodEnv = require('./prod.env')
 module.exports = merge(prodEnv, {
   NODE_ENV: '"development"',
   // urlVGI: '"http://localhost:3001"',
-  urlVGI: '"http://www.pauliceia.dpi.inpe.br/api/vgi"',
+  urlVGI: '"http://localhost:8888"',
   // urlGeoserverPauliceia: '"http://localhost:9021/geoserver/pauliceia"',
-  urlGeoserverPauliceia: '"http://www.pauliceia.dpi.inpe.br/geoserver/pauliceia"',
-  urlGeoserveOther: '"http://www.pauliceia.dpi.inpe.br/geoserver/other"',
-  urlGeocoding: '"http://www.pauliceia.dpi.inpe.br/api/geocoding"',
+  urlGeoserverPauliceia: '"https://pauliceia.unifesp.brgeoserver/pauliceia"',
+  urlGeoserveOther: '"https://pauliceia.unifesp.br/geoserver/other"',
+  urlGeocoding: '"https://pauliceia.unifesp.br/api/geocoding"',
   keyCripto: '"keytest"'
 })

--- a/src/views/pages/dashboard/home.vue
+++ b/src/views/pages/dashboard/home.vue
@@ -83,9 +83,11 @@
     },
     methods: {
       deleteLayer(id){
-        Api().delete('/api/layer/' + id).then((response) => {
+        if(window.confirm("Você tem certeza que deseja deletar esta camada?")){
+          Api().delete('/api/layer/' + id).then((response) => {
           this.updateLayers()
         })
+        }
       },
       editLayer(id){
         this.$router.push({name: 'EditLayer', params: {layer_id: id}})


### PR DESCRIPTION
Essa PR adiciona a funcionalidade de confirmar a ação do usuário antes de excluir uma camada. Quando o usuário clica no botão de deletar, um diálogo pergunta ao usuário se ele deseja confirmar a exclusão. Essa funcionalidade não possui nenhuma dependência.

A melhoria visa aumentar a experiência do usuário na plataforma, como a ação de excluir uma camada é permanente, é importante que o usuário seja capaz de cancelar a ação.

Os testes para a funcionalidade se encontram no seguinte repositório e branch: https://github.com/IgorAugst/testes_pauliceia/tree/feature/confirma-exclusao