### PR TITLE
Regex para senha mais forte na criação de conta.

### DIFF
--- a/src/views/pages/register.vue
+++ b/src/views/pages/register.vue
@@ -29,7 +29,7 @@
                         </div>
                         <div class="form-group col-md-6">
                             <label>{{ $t('register.lbPassword') }}</label>
-                            <input type="password" v-model="user.password" class="form-control form-control-lg" :placeholder="$t('register.lbPassword')" required>
+                            <input type="password" v-model="user.password" class="form-control form-control-lg" :placeholder="$t('register.lbPassword')" pattern="^(?=.*[a-z])(?=.*[A-Z])(?=.*\d)(?=.*[@$!%*?&#])[A-Za-z\d@$!%*?&]{8,}$" title="Deve conter pelo menos um número, uma letra maiúscula e minúscula, um caracter especial (!, @, #, $, %, &, *, ?) e pelo menos 8 ou mais carateres" required>
                         </div>
                     </div>
 


### PR DESCRIPTION
Adicionado uma regex (um número, uma letra maiúscula e uma letra minúscula, carácter especial (!@#$%&*?) e no mínimo oito caracteres) para a senha no momento da criação do usuário. Adicionado um atributo pattern no input da senha para não permitir que o usuário criar uma conta sem que as condições da expressão regular forem atendidas.
Atualmente é possível criar usuário com senhas sendo apenas um número. Exemplo de senha: 1.