### PR TITLE
Adding verification of the uploaded CSV file to check if it's really a .csv extension

### DIFF
--- a/src/views/components/map/Geocoding.vue
+++ b/src/views/components/map/Geocoding.vue
@@ -186,6 +186,20 @@ export default {
     handleFileChange(event) {
       this._openFullScreen()
 
+      // Check if a file was selected
+      if (!event.target.files || event.target.files.length === 0) {
+        this._msgError('No file selected.');
+        return;
+      }
+
+      const selectedFile = event.target.files[0];
+      
+      // Check if the file has a CSV extension
+      if (!selectedFile.name.toLowerCase().endsWith('.csv')) {
+        this._msgError('Formato de arquivo invalido. Por favor insira um arquivo .CSV');
+        return;
+      }
+
       // add default values
       this.headers = []
       this.showDownloadButton = false


### PR DESCRIPTION
## Describe your changes

Adding verification of the uploaded CSV file to check if it's really a .csv extension.

## Why

Before that, we could upload any kind of file extension in there, and then click "visualizar" which would result in an infinite "geocodificando" bug.

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] If it is a core feature, I have added thorough tests.
- [x] Eyeballed tests
- [ ] Will this be part of a product update? If yes, please write one phrase about this update.