### PR TITLE
Adding a new tutorial page in english and portuguese

### DIFF
--- a/src/views/components/application/Header.vue
+++ b/src/views/components/application/Header.vue
@@ -27,10 +27,10 @@
                             to="/explore">{{ $t('nav.map') }}</router-link>
                     </li>
                     <li class="nav-item">
-                      <!--<router-link
+                      <router-link
                           :class="this.$route.path == '/tutorial' ? 'nav-link active': 'nav-link'"
-                          to="/tutorial">Tutorial</router-link>-->
-                      <a :class="this.$route.path == '/tutorial' ? 'nav-link active': 'nav-link'" href="https://drive.google.com/drive/folders/1M7iU2iz46i2gIgfctkUCZdBARWJykcoT?usp=sharing" target="_blank" >Tutorial</a>
+                          to="/tutorial">Tutorial</router-link>
+                      <!-- <a :class="this.$route.path == '/tutorial' ? 'nav-link active': 'nav-link'" href="https://drive.google.com/drive/folders/1M7iU2iz46i2gIgfctkUCZdBARWJykcoT?usp=sharing" target="_blank" >Tutorial</a> -->
                     </li>
                     <li class="nav-item">
                       <router-link

--- a/src/views/language/translations/english.js
+++ b/src/views/language/translations/english.js
@@ -135,6 +135,14 @@ export default {
         "unifesp": "Federal University of Sao Paulo (UNIFESP)",
       },
     },
+    "tutorial":{
+        "tutorial1": "English tutorial",
+        "tutorial2": "Here we have a use guide in English for Pauliceia:",
+        "download1": "Download in English",
+        "links":{
+            "download2" : "https://drive.usercontent.google.com/download?id=1UT6T0Kg6w32Nht4-guRdl8bz5eDU3J9D&export=download&authuser=0&confirm=t&uuid=2b73c372-6e57-440b-ae24-ae7e0dc7fc81&at=APZUnTX_jBmgytAze90q-0oMMSdR:1705202461993",
+        },
+    },
     "about":{
         "title1": "Who developed it?",
         "title2": "Who finaced it?",

--- a/src/views/language/translations/portuguese.js
+++ b/src/views/language/translations/portuguese.js
@@ -136,6 +136,14 @@ export default {
         "unifesp": "Universidade Federal de SP (UNIFESP)",
       },
     },
+    "tutorial":{
+        "tutorial1": "Tutorial em Português",
+        "tutorial2": "Aqui temos um tutorial de como utilizar o Pauliceia:",
+        "download1": "Download em Português",
+        "links":{
+            "download2" : "https://drive.usercontent.google.com/download?id=196wlzsvMM-YHeLA2nQ77JSdtjMpq1eDM&export=download&authuser=0&confirm=t&uuid=f41e5617-69cb-4336-95ee-3b026daeb492&at=APZUnTXfAKngUcgOX8tJ6vxQoTmq:1705200007504",
+        },
+    },
     "about":{
       "title1": "Quem desenvolveu?",
       "title2": "Quem financiou?",

--- a/src/views/pages/tutorial.vue
+++ b/src/views/pages/tutorial.vue
@@ -1,26 +1,109 @@
-<template>
+<!-- <template>
     <div class="cont">
       <embed src="/static/pdf/tutorial_pauliceia.pdf" class="pdf">
     </div>
+</template> -->
+<template>
+  <section class="page-weapper" itemscope itemtype="http://schema.org/CreativeWork">
+
+    <div class="container">
+      <header class="row row-style justify-content-md-center">
+        <div class="col-sm-4 column-style">
+          <div class="card card-style">
+            <div class="card-body"><br>
+              <h5 class="card-title">{{ $t('tutorial.tutorial1') }}</h5><br>
+              <div class="card-text" itemprop="about" v-html="$t('tutorial.tutorial2')"/>
+              <div class="row row-style justify-content-md-center">
+                <a :href="$t('tutorial.links.download2')" class="btn btn-download">{{ $t('tutorial.download1') }}</a>
+              </div>
+            </div>
+          </div>
+        </div>
+      </header>
+    </div>
+
+  </section>
 </template>
 
 <script>
+import HowToCite from '@/views/components/HowToCite.vue'
+
+export default {
+  components: {
+    HowToCite
+  }
+}
+</script>
+
+<!-- <script>
     export default {
         name: "tutorial"
     }
-</script>
+</script> -->
+
 
 <style lang="sass" scoped>
-  *
-    box-sizing: border-box
-    margin: 0
-    padding: 0
+  .page-weapper
 
-  .pdf
-    position: relative
-    width:  100%
-    height: 90.75vh
+    .container
 
-  .cont
-    height: max-content
+      
+
+      position: relative
+      padding-top: 300px
+      padding-bottom: 50px
+
+      .column-style:first-child
+        padding-left: 0
+
+      .column-style:last-child
+        padding-right: 0
+
+      .card-style
+        border-radius: 20px
+        background-color: #ffb364
+        min-height: 300px
+
+        .card-text
+          font-size: 16px
+          margin-bottom: 20px;
+
+        .btn-download
+          color: #FFF
+          background: #f15a29
+          font-family: IrisUPC
+          font-size: 30px
+          padding: 0 20px
+          border-radius: 7.5px
+          line-height: 1
+          a
+              list-decoration: none
+
+    .container2
+      background-color: #c6c6c6
+      padding-bottom: 50px
+
+      .container
+        padding: 0
+
+      .row
+        margin: 0
+
+      .row-style
+        padding-bottom: 50px
+
+      .title2
+        position: relative
+        padding-top: 20px
+
+
+    .picture
+      position: relative
+      top: 20px
+
+    .picture2
+      position: relative
+      top: 0px
+      padding-top: 20px
+      width: 400px
 </style>


### PR DESCRIPTION
## Describe your changes
Adding a new tutorial page in english and portuguese with one container that has a download button for the tutorial pdf, added the routes for it, and the download links come from the pauliceia google drive downloads [https://drive.google.com/drive/folders/1M7iU2iz46i2gIgfctkUCZdBARWJykcoT], and can be easily altered through the localization files (I.e: portuguese.js and english.js).

## Why?
Because, as the final user. I wouldn't want to be redirected to a google drive, which breaks the experience. We thought it would be easier to just download the tutorial on the selected language instead without ever leaving the comfort of the pauliceia webpage.

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] If it is a core feature, I have added thorough tests.
- [x] Eyeballed tests
- [ ] Will this be part of a product update? If yes, please write one phrase about this update.

