### PR TITLE
[GRUPO 1] - Melhoria técnica: Confirmação para executar deleção de camada

### DIFF
--- a/config/dev.env.js
+++ b/config/dev.env.js
@@ -5,10 +5,10 @@ const prodEnv = require('./prod.env')
 module.exports = merge(prodEnv, {
   NODE_ENV: '"development"',
   // urlVGI: '"http://localhost:3001"',
-  urlVGI: '"http://localhost:8888"',
+  urlVGI: '"http://www.pauliceia.dpi.inpe.br/api/vgi"',
   // urlGeoserverPauliceia: '"http://localhost:9021/geoserver/pauliceia"',
-  urlGeoserverPauliceia: '"https://pauliceia.unifesp.brgeoserver/pauliceia"',
-  urlGeoserveOther: '"https://pauliceia.unifesp.br/geoserver/other"',
-  urlGeocoding: '"https://pauliceia.unifesp.br/api/geocoding"',
+  urlGeoserverPauliceia: '"http://www.pauliceia.dpi.inpe.br/geoserver/pauliceia"',
+  urlGeoserveOther: '"http://www.pauliceia.dpi.inpe.br/geoserver/other"',
+  urlGeocoding: '"http://www.pauliceia.dpi.inpe.br/api/geocoding"',
   keyCripto: '"keytest"'
 })

--- a/config/dev.env.js
+++ b/config/dev.env.js
@@ -5,10 +5,10 @@ const prodEnv = require('./prod.env')
 module.exports = merge(prodEnv, {
   NODE_ENV: '"development"',
   // urlVGI: '"http://localhost:3001"',
-  urlVGI: '"http://www.pauliceia.dpi.inpe.br/api/vgi"',
+  urlVGI: '"http://localhost:8888"',
   // urlGeoserverPauliceia: '"http://localhost:9021/geoserver/pauliceia"',
-  urlGeoserverPauliceia: '"http://www.pauliceia.dpi.inpe.br/geoserver/pauliceia"',
-  urlGeoserveOther: '"http://www.pauliceia.dpi.inpe.br/geoserver/other"',
-  urlGeocoding: '"http://www.pauliceia.dpi.inpe.br/api/geocoding"',
+  urlGeoserverPauliceia: '"https://pauliceia.unifesp.brgeoserver/pauliceia"',
+  urlGeoserveOther: '"https://pauliceia.unifesp.br/geoserver/other"',
+  urlGeocoding: '"https://pauliceia.unifesp.br/api/geocoding"',
   keyCripto: '"keytest"'
 })

--- a/src/views/pages/dashboard/home.vue
+++ b/src/views/pages/dashboard/home.vue
@@ -83,9 +83,11 @@
     },
     methods: {
       deleteLayer(id){
-        Api().delete('/api/layer/' + id).then((response) => {
+        if(window.confirm("Você tem certeza que deseja deletar esta camada?")){
+          Api().delete('/api/layer/' + id).then((response) => {
           this.updateLayers()
         })
+        }
       },
       editLayer(id){
         this.$router.push({name: 'EditLayer', params: {layer_id: id}})


### PR DESCRIPTION
Neste PR, estamos incluindo a validação para deletar camadas, conforme solicitação dos usuários na planilha de sugestões.
Agora ao clicar em deletar, o browser irá abrir um prompt com a confirmação da exclusão, ao clicar em "Sim", o método que apaga a camada será executado.