### PR TITLE
[Grupo 4] Feature Melhorias nas Traduções

### DIFF
--- a/src/views/components/Terms.vue
+++ b/src/views/components/Terms.vue
@@ -14,7 +14,7 @@
                 </div>
 
                 <div class="modal-footer">
-                    <button type="button" class="btn btn-secondary" data-dismiss="modal">Close</button>
+                    <button type="button" class="btn btn-secondary" data-dismiss="modal">{{ $t('terms.close') }}</button>
                 </div>
             </div>
         </div>

--- a/src/views/components/dashboard/ModalNotification.vue
+++ b/src/views/components/dashboard/ModalNotification.vue
@@ -1,8 +1,8 @@
 <template>
   <div>
-    <el-button type="text" @click="showModal2()">Comments</el-button>
+    <el-button type="text" @click="showModal2()">{{ $t('dashboard.notification.comments') }}</el-button>
 
-    <el-dialog title="Notification" :visible.sync="outerVisible" id="myModal" :append-to-body="true" class="mod">
+    <el-dialog :title="$t('dashboard.notification.notification')" :visible.sync="outerVisible" id="myModal" :append-to-body="true" class="mod">
 
       <div class="notification-box">
         <div style="display: flex; align-items: center;">
@@ -19,7 +19,7 @@
         <textarea class="form-control" v-model="txtNotif" id="inputReference" rows="3"></textarea>
         <br>
         <div style="right: 30px; position: absolute">
-          <a class="btn btn-primary" @click="addNotif()" style="color: white">Submit</a>
+          <a class="btn btn-primary" @click="addNotif()" style="color: white">{{ $t('dashboard.notification.comments') }}</a>
         </div>
         <p style="left: 0px; display: flex">{{txtReply}}&nbsp;&nbsp;&nbsp;
           <button type="button" class="btn btn-outline-danger btn-sm add" @click="clearMsg()" v-if="txtReply !== null">
@@ -43,13 +43,13 @@
 
             <p class="content">{{n.description}}</p>
             <p class="comments">
-              <button type="button" class="btn btn-outline-primary btn-sm add" @click="replyNot(n)" title="Responder" v-if=false>
+              <button type="button" class="btn btn-outline-primary btn-sm add" @click="replyNot(n)" :title="$t('dashboard.notification.answer')" v-if=false>
                 <md-icon>replay</md-icon>
               </button>
-              <button type="button" class="btn btn-outline-warning btn-sm add" @click="reportNot(n)" title="Denunciar" v-if=false>
+              <button type="button" class="btn btn-outline-warning btn-sm add" @click="reportNot(n)" :title="$t('dashboard.notification.report')" v-if=false>
                 <md-icon>report</md-icon>
               </button>
-              <button type="button" class="btn btn-outline-danger btn-sm add" @click="clearNot(n)" v-if="user.user_id === n.user_id_creator || user.is_the_admin" title="Excluir">
+              <button type="button" class="btn btn-outline-danger btn-sm add" @click="clearNot(n)" v-if="user.user_id === n.user_id_creator || user.is_the_admin" :title="$t('dashboard.notification.clear')">
                 <md-icon>clear</md-icon>
               </button>
             </p>
@@ -58,7 +58,7 @@
       </div>
 
       <div slot="footer" class="dialog-footer">
-        <el-button @click="outerVisible = false">Close</el-button>
+        <el-button @click="outerVisible = false">{{ $t('dashboard.notification.close') }}</el-button>
         <!--<el-button type="primary" @click="innerVisible = true">Close</el-button>-->
       </div>
     </el-dialog>

--- a/src/views/components/dashboard/Notifications.vue
+++ b/src/views/components/dashboard/Notifications.vue
@@ -2,13 +2,13 @@
   <div class="body">
 
     <el-tabs v-model="activeName" @tab-click="handleClick">
-      <el-tab-pane label="GENERAL" name="first" class="">
+      <el-tab-pane :label="$t('dashboard.notification.general')" name="first" class="">
         <div class="notification-box-main" v-if="showInput">
           <textarea class="form-control" v-model="txtNotif" id="inputReference" rows="3"></textarea>
           <br>
           <div style="float: right">
             <a class="btn btn-dark" @click="addNotif()"
-               style="color: white; background-color: #ff6107; border-color: #ff6107">Submit</a>
+               style="color: white; background-color: #ff6107; border-color: #ff6107">{{ $t('dashboard.notification.submit') }}</a>
           </div>
           <p style="left: 0px; display: flex">{{txtReply}}&nbsp;&nbsp;&nbsp;
             <button type="button" class="btn btn-outline-danger btn-sm add" @click="clearMsg()"
@@ -35,15 +35,15 @@
               <div class="col-9 col-md-9  col-lg-11 col-sm-9">
                 <div class="comments">
                   <button type="button" class="btn btn-outline-primary btn-sm add" @click="replyNot(notification)"
-                          v-if="showInput" title="Responder">
+                          v-if="showInput" :title="$t('dashboard.notification.answer')">
                     <md-icon>replay</md-icon>
                   </button>
                   <button type="button" class="btn btn-outline-warning btn-sm add" @click="reportNot(notification)"
-                          v-if="showInput" title="Denunciar">
+                          v-if="showInput" :title="$t('dashboard.notification.report')">
                     <md-icon>report</md-icon>
                   </button>
                   <button type="button" class="btn btn-outline-danger btn-sm add" @click="clearNot(notification)"
-                          v-if="canUserRemoveIt(notification)" title="Excluir">
+                          v-if="canUserRemoveIt(notification)" :title="$t('dashboard.notification.clear')">
                     <md-icon>clear</md-icon>
                   </button>
                 </div>
@@ -59,12 +59,12 @@
         </div>
       </el-tab-pane>
 
-      <el-tab-pane label="PERSONAL" name="second">
+      <el-tab-pane :label="$t('dashboard.notification.personal')" name="second">
         <div class="notification-box-main" v-if="showInput && showInput2">
           <textarea class="form-control" v-model="txtNotif" id="inputReference2" rows="3"></textarea>
           <br>
           <div style="right: 30px; position: absolute">
-            <a style="color: white" class="btn btn-primary" @click="addNotif()">Submit</a>
+            <a style="color: white" class="btn btn-primary" @click="addNotif()">{{ $t('dashboard.notification.submit') }}</a>
           </div>
           <p style="left: 0px; display: flex">{{txtReply}}&nbsp;&nbsp;&nbsp;
             <button type="button" class="btn btn-outline-danger btn-sm add" @click="clearMsg()"
@@ -92,15 +92,15 @@
                 <div class="col-9 col-md-9  col-lg-11 col-sm-9">
                   <div class="comments">
                     <button type="button" class="btn btn-outline-primary btn-sm add" @click="replyNot(notification)"
-                            v-if="showInput" title="Responder">
+                            v-if="showInput" :title="$t('dashboard.notification.answer')">
                       <md-icon>replay</md-icon>
                     </button>
                     <button type="button" class="btn btn-outline-warning btn-sm add" @click="reportNot(notification)"
-                            v-if="showInput" title="Denunciar">
+                            v-if="showInput" :title="$t('dashboard.notification.report')">
                       <md-icon>report</md-icon>
                     </button>
                     <button type="button" class="btn btn-outline-danger btn-sm add" @click="clearNot(notification)"
-                            v-if="canUserRemoveIt(notification)">
+                            v-if="canUserRemoveIt(notification)" :title="$t('dashboard.notification.clear')">
                       <md-icon>clear</md-icon>
                     </button>
                   </div>
@@ -113,23 +113,23 @@
                 </div>
               </div>
               <div class="msgType">
-                <div class="msgType" v-if="notification.is_denunciation !== false">Denunciation&nbsp;
-                  <div v-if="notification.notification_id_parent !== null">of your message on layer {{notification.layer_name}}</div>
-                  <div v-else-if="notification.layer_id !== null">of your layer {{notification.layer_name}}</div>
-                  <div v-else>of your message on your global notification</div>
+                <div class="msgType" v-if="notification.is_denunciation !== false">{{$t("dashboard.notification.denunciation")}}&nbsp;
+                  <div v-if="notification.notification_id_parent !== null">{{$t("dashboard.notification.ofYourMessage")}} {{notification.layer_name}}</div>
+                  <div v-else-if="notification.layer_id !== null">{{$t("dashboard.notification.ofYourLayer")}} {{notification.layer_name}}</div>
+                  <div v-else>{{$t("dashboard.notification.ofYourMessageGlobalNotification")}}</div>
                 </div>
 
                 <div v-else-if="notification.layer_id !== null && notification.type === 'myLayer'">
-                  Comment on your layer {{notification.layer_name}}
+                  {{$t("dashboard.notification.commentYourLayer")}} {{notification.layer_name}}
                 </div>
 
                 <div class="msgType" v-else-if="notification.notification_id_parent !== null && notification.type === 'message'">
-                  Reply of your message&nbsp;
+                  {{$t("dashboard.notification.replyYourLayer")}}&nbsp;
                   <div v-if="notification.layer_id !== null">
-                    on your layer {{notification.layer_name}}
+                    {{$t("dashboard.notification.onYourLayer")}} {{notification.layer_name}}
                   </div>
                   <div v-else>
-                    on your global notification
+                    {{$t("dashboard.notification.onYourGlobalNotification")}}
                   </div>
                 </div>
               </div>
@@ -138,12 +138,12 @@
         </div>
       </el-tab-pane>
 
-      <el-tab-pane label="FOLLOWING" name="thrid">
+      <el-tab-pane :label="$t('dashboard.notification.following')" name="thrid">
         <div class="notification-box-main" v-if="showInput && showInput2">
           <textarea class="form-control" v-model="txtNotif" id="inputReference3" rows="3"></textarea>
           <br>
           <div style="right: 30px; position: absolute">
-            <a style="color: white" class="btn btn-primary" @click="addNotif()">Submit</a>
+            <a style="color: white" class="btn btn-primary" @click="addNotif()">{{ $t('dashboard.notification.submit') }}</a>
           </div>
           <p style="left: 0px; display: flex">{{txtReply}}&nbsp;&nbsp;&nbsp;
             <button type="button" class="btn btn-outline-danger btn-sm add" @click="clearMsg()"
@@ -173,15 +173,15 @@
                 <div class="col-9 col-md-9  col-lg-11 col-sm-9">
                   <p class="comments">
                     <button type="button" class="btn btn-outline-primary btn-sm add" @click="replyNot(notification)"
-                            v-if="showInput" title="Responder">
+                            v-if="showInput" :title="$t('dashboard.notification.answer')">
                       <md-icon>replay</md-icon>
                     </button>
                     <button type="button" class="btn btn-outline-warning btn-sm add" @click="reportNot(notification)"
-                            v-if="showInput" title="Denunciar">
+                            v-if="showInput" :title="$t('dashboard.notification.report')">
                       <md-icon>report</md-icon>
                     </button>
                     <button type="button" class="btn btn-outline-danger btn-sm add" @click="clearNot(notification)"
-                            v-if="canUserRemoveIt(notification)" title="Excluir">
+                            v-if="canUserRemoveIt(notification)" :title="$t('dashboard.notification.clear')">
                       <md-icon>clear</md-icon>
                     </button>
                   </p>
@@ -195,29 +195,29 @@
               </div>
               <div class="msgType">
                 <div class="msgType" v-if="notification.is_denunciation !== false">
-                  Denunciation&nbsp;
+                  {{$t("dashboard.notification.denunciation")}}&nbsp;
                   <div v-if="notification.notification_id_parent !== null">
-                    of some message on layer {{notification.layer_name}}
+                    {{$t("dashboard.notification.ofSomeMessage")}} {{notification.layer_name}}
                   </div>
                   <div v-else-if="notification.layer_id !== null">
-                    of layer {{notification.layer_name}}
+                    {{$t("dashboard.notification.ofLayer")}} {{notification.layer_name}}
                   </div>
                   <div v-else>
-                    of your message on global notification
+                    {{$t("dashboard.notification.ofYourMessageonGlobal")}}
                   </div>
                 </div>
 
                 <div class="msgType" v-else-if="notification.notification_id_parent !== null">
-                  Reply of some message&nbsp;
+                  {{$t("dashboard.notification.replySomeMessage")}}&nbsp;
                   <div v-if="notification.layer_id !== null">
-                    on layer {{notification.layer_name}}
+                    {{$t("dashboard.notification.onLayer")}} {{notification.layer_name}}
                   </div>
                   <div v-else>
-                    on global notification
+                    {{$t("dashboard.notification.onGlobalNotification")}}
                   </div>
                 </div>
                 <div v-else>
-                  Comment on layer {{notification.layer_name}}
+                  {{$t("dashboard.notification.commentLayer")}} {{notification.layer_name}}
                 </div>
               </div>
             </div>

--- a/src/views/components/map/BoxInfoLayer.vue
+++ b/src/views/components/map/BoxInfoLayer.vue
@@ -53,7 +53,7 @@
                 <textarea class="form-control" v-model="txtNotif" id="inputReference" rows="3"></textarea>
                 <br>
                 <div style="right: 60px; position: absolute">
-                  <a class="btn btn-primary" @click="addNotif()" style="color: white">Submit</a>
+                  <a class="btn btn-primary" @click="addNotif()" style="color: white">{{ $t('map.viewInfo.submit') }}</a>
                 </div>
                 <div style="right: 150px; position: absolute">
                   <a class="btn btn-warning" @click="addNotifD()"><md-icon>report</md-icon></a>

--- a/src/views/components/map/BoxNotifications.vue
+++ b/src/views/components/map/BoxNotifications.vue
@@ -1,79 +1,79 @@
 <template>
-    <div class="box-info" v-show="boxNotifications">
-      <header class="header">
-        <h1>Notifications</h1>
-        <button class="btn" @click="closeBox()">
-          <md-icon>close</md-icon>
-        </button>
-      </header>
-      <p-notifications></p-notifications>
-    </div>
+  <div class="box-info" v-show="boxNotifications">
+    <header class="header">
+      <h1>{{ $t('dashboard.notification.notification') }}</h1>
+      <button class="btn" @click="closeBox()">
+        <md-icon>close</md-icon>
+      </button>
+    </header>
+    <p-notifications></p-notifications>
+  </div>
 </template>
 
 <script>
-  import Api from '@/middleware/ApiVGI'
-  import { mapState } from 'vuex'
-  import Notifications from '@/views/components/dashboard/Notifications'
+import Api from '@/middleware/ApiVGI'
+import { mapState } from 'vuex'
+import Notifications from '@/views/components/dashboard/Notifications'
 
 export default {
-    components: {
-      'p-notifications': Notifications
-    },
-    computed: {
-      ...mapState('map', ['boxNotifications'])
-    },
-    data() {
-      return {
-        activeName: 'first'
-      };
-    },
-    methods: {
-        closeBox() {
-            this.$store.dispatch('map/setBoxNotifications', false)
-        },
-    }
+  components: {
+    'p-notifications': Notifications
+  },
+  computed: {
+    ...mapState('map', ['boxNotifications'])
+  },
+  data() {
+    return {
+      activeName: 'first'
+    };
+  },
+  methods: {
+      closeBox() {
+          this.$store.dispatch('map/setBoxNotifications', false)
+      },
+  }
 }
 </script>
 
 <style lang="sass" scoped>
 .box-info
-    position: absolute
-    top: 20px
-    right: 60px
-    border-radius: 10px
-    overflow: auto
-    padding: 10px
-    background: rgba(#FFF, 0.7)
-    z-index: 1
-    max-width: 40%
-    min-width: 40%
-    max-height: 75%
+  position: absolute
+  top: 20px
+  right: 60px
+  border-radius: 10px
+  overflow: auto
+  padding: 10px
+  background: rgba(#FFF, 0.7)
+  z-index: 1
+  max-width: 40%
+  min-width: 40%
+  max-height: 75%
 
-    .header
-        width: 100%
-        border-bottom: 1px solid #f15a29
-        h1
-            padding: 5px 5px 10px 5px
-            font-size: 1.3em
-            font-weight: 400
-            font-family: 'Roboto' !important
-            display: inline-block
-            margin: 0 !important
+  .header
+      width: 100%
+      border-bottom: 1px solid #f15a29
+      h1
+          padding: 5px 5px 10px 5px
+          font-size: 1.3em
+          font-weight: 400
+          font-family: 'Roboto' !important
+          display: inline-block
+          margin: 0 !important
 
-        .btn
-            margin: 3px !important
-            padding: 2px !important
-            background: none
-            font-size: 1em
-            border: none
-            float: right
-            display: inline-block
-        .btn:hover
-            background: rgba(#000, 0.1)
+      .btn
+          margin: 3px !important
+          padding: 2px !important
+          background: none
+          font-size: 1em
+          border: none
+          float: right
+          display: inline-block
+      .btn:hover
+          background: rgba(#000, 0.1)
 
-    .body
-        padding: 10px 20px
-        background: #FFF
+  .body
+      padding: 10px 20px
+      background: #FFF
 
 
 </style>

--- a/src/views/components/map/sidebar-layer/LayersItemOther.vue
+++ b/src/views/components/map/sidebar-layer/LayersItemOther.vue
@@ -22,12 +22,12 @@ export default {
             layers: [
                 {
                     title: 'mde_sp_colored',
-                    titleReal: 'Modelo Digital de Elevação de São Paulo (colorido)',
+                    titleReal: this.$t('map.sidebarLayer.mde_sp_colore'),
                     status: false
                 },
                 {
                     title: 'mde_sp_bw',
-                    titleReal: 'Modelo Digital de Elevação de São Paulo (tons de cinza)',
+                    titleReal: this.$t('map.sidebarLayer.mde_sp_bw'),
                     status: false
                 }
             ]

--- a/src/views/language/translations/english.js
+++ b/src/views/language/translations/english.js
@@ -30,6 +30,33 @@ export default {
             "myLayers": "My Layers",
             "sharedLayers": "Shared Layers"
         },
+        "notification":{
+            "notification":"Notification",
+            "general": "GENERAL",
+            "personal": "PERSONAL",
+            "following": "FOLLOWING",
+            "comments": "Comments",
+            "answer": "Answer",
+            "report": "Report",
+            "submit": "Submit",
+            "clear": "Clear",
+            "close": "Close",
+            "denunciation": "Denunciation",
+            "ofYourMessage": "of your message on layer",
+            "ofYourLayer": "of your layer",
+            "ofYourMessageGlobalNotification": "of your message on your global notification",
+            "commentYourLayer": "Comment on your layer",
+            "replyYourLayer": "Reply of your message",
+            "onYourLayer": "on your layer",
+            "onYourGlobalNotification": "on your global notification",
+            "ofSomeMessage":"of some message on layer",
+            "ofLayer":"of layer",
+            "ofYourMessageonGlobal":"of your message on global notification",
+            "replySomeMessage":"Reply of some message",
+            "onLayer": "on layer",
+            "onGlobalNotification":"on global notification",
+            "commentLayer":"Comment on layer"
+        },
         "newLayer": {
             "name": "Name",
             "keywords": "Keywords",
@@ -90,7 +117,18 @@ export default {
             "newKeyword": "New Keyword",
             "myKeywords": "My Keywords",
             "nameD": "Name of the new keyword. It is unique in the system.",
-            "name": "Name"
+            "name": "Name",
+            "submit": "Submit"
+        }, 
+        "profile":{
+            "profile": "My Profile",
+            "name": "Name",
+            "submit": "Submit",
+            "uploadNewPicture": "Upload New Picture",
+            "profilePicture": "Profile Picture",
+            "emailMessage": "It is not possible to modify the email",
+            "usernameMessage": "Social Name",
+            "profilePictureMessage" : "Picture for Profile"
         }
     },
     "login": {
@@ -100,6 +138,8 @@ export default {
         "btnText": "Login",
         "terms": "If you sign in with the social network, you automatically agree to the terms of the project.",
         "lbReadme": "read the terms here",
+        "loginAccount": "Login your account",
+        "loginGoogle": "Login with Google+",
         "msg": {
             "success": "WELCOME",
             "err404": "<strong>Email</strong> or <strong>password</strong> incorrect!",
@@ -218,6 +258,7 @@ export default {
         "btnTitle": "Register",
         "lbToLogin": "Are you already registered?",
         "lbToLoginLink": "CLICK HERE",
+        "submit": "Submit",
         "msg": {
             "registerBtnHover": "You must accept the Use Terms in order to register yourself!",
             "success": "Your registration is almost ready. Just access your email and follow the instructions.",
@@ -270,7 +311,9 @@ export default {
                 "editColor": "Edit color",
                 "download": "Download"
             },
-            "msgEmpty": "Add layers to the view on the map!"
+            "msgEmpty": "Add layers to the view on the map!",
+            "mde_sp_colore": "Digital Model of Sao Paulo Elevation (colore)",
+            "mde_sp_bw": "Digital Model of Sao Paulo Elevation (grey shades)"
         },
         "sidebarEdit": {
             "title": "Edit"
@@ -302,7 +345,8 @@ export default {
             "lbAuthors": "AUTHORS",
             "lbDate": "CREATION DATE",
             "lbReferences": "REFERENCES",
-            "lbNotifications": "Notifications"
+            "lbNotifications": "Notifications",
+            "submit": "Submit"
         },
         "viewInfoVector": {
             "title": "Select Information",
@@ -332,6 +376,7 @@ export default {
     },
     "terms": {
         "title": "USE TERMS",
-        "text": termsEN
+        "text": termsEN,
+        "close": "Close"
     }
 }

--- a/src/views/language/translations/portuguese.js
+++ b/src/views/language/translations/portuguese.js
@@ -30,6 +30,33 @@ export default {
             "myLayers": "Minhas Camadas",
             "sharedLayers": "Camadas Compartilhadas"
         },
+        "notification":{
+            "notification":"Notificação",
+            "general": "GERAL",
+            "personal": "PESSOAL",
+            "following": "SEGUINDO",
+            "comments": "Comentários",
+            "answer": "Responder",
+            "report": "Denunciar",
+            "submit": "Enviar",
+            "clear": "Excluir",
+            "close": "Fechar",
+            "denunciation": "Denúncia",
+            "ofYourMessage": "da sua mensagem na camada",
+            "ofYourLayer": "da sua camada",
+            "ofYourMessageGlobalNotification": "da sua mensagem nas suas notificações globais",
+            "commentYourLayer": "Comente na sua camada",
+            "replyYourLayer": "Resposta da sua mensagem",
+            "onYourLayer": "na sua camada",
+            "onYourGlobalNotification": "nas suas notificações globais",
+            "ofSomeMessage":"de alguma mensagem na camada",
+            "ofLayer":"da camada",
+            "ofYourMessageonGlobal":"da sua mensagem nas notificações globais",
+            "replySomeMessage":"Responder a algumas mensagens",
+            "onLayer": "na camada",
+            "onGlobalNotification":"nas notificações globais",
+            "commentLayer":"Comentar na camada"
+        },
         "newLayer": {
             "name": "Nome",
             "keywords": "Palavras-chave",
@@ -91,7 +118,18 @@ export default {
             "newKeyword": "Nova Palavra-Chave",
             "myKeywords": "Minhas Palavras-Chave",
             "nameD": "Nome da nova palavra-chave. Ela é única no sistema.",
-            "name": "Nome"
+            "name": "Nome",
+            "submit": "Enviar"
+        },
+        "profile":{
+            "profile": "Meu Perfil",
+            "name": "Nome",
+            "submit": "Enviar",
+            "uploadNewPicture": "Enviar Nova Foto",
+            "profilePicture": "Foto de Perfil",
+            "emailMessage": "Não é possível modificar o e-mail",
+            "usernameMessage": "Nome social",
+            "profilePictureMessage" : "Foto para o perfil"
         }
     },
     "login": {
@@ -101,6 +139,8 @@ export default {
         "btnText": "Entrar",
         "terms": "Se você fizer login via rede social, estará automaticamente concordando com os termos do projeto.",
         "lbReadme": "leia os termos aqui",
+        "loginAccount": "Acesse sua conta",
+        "loginGoogle": "Acesso com o Google+",
         "msg": {
             "success": "BEM-VINDO",
             "err404": "<strong>E-mail</strong> ou <strong>senha</strong> incorreta!",
@@ -219,6 +259,7 @@ export default {
         "btnTitle": "Cadastrar",
         "lbToLogin": "Você já está cadastrado?",
         "lbToLoginLink": "CLIQUE AQUI",
+        "submit": "Enviar",
         "msg": {
             "registerBtnHover": "Você deve aceitar os Termos de Uso para se registrar!",
             "success": "O teu cadastro está quase pronto. Basta acessar o teu e-mail e seguir as instruções.",
@@ -271,7 +312,9 @@ export default {
                 "editColor": "Mudar a cor",
                 "download": "Baixar .shp"
             },
-            "msgEmpty": "Adicione as camadas para a visualização no mapa!"
+            "msgEmpty": "Adicione as camadas para a visualização no mapa!",
+            "mde_sp_colore": "Modelo Digital de Elevação de São Paulo (colorido)",
+            "mde_sp_bw": "Modelo Digital de Elevação de São Paulo (tons de cinza)"
         },
         "sidebarEdit": {
             "title": "Editor"
@@ -303,7 +346,8 @@ export default {
             "lbAuthors": "AUTORES",
             "lbDate": "DATA DE CRIAÇÃO",
             "lbReferences": "REFERÊNCIAS",
-            "lbNotifications": "Notificações"
+            "lbNotifications": "Notificações",
+            "submit": "Enviar"
         },
         "viewInfoVector": {
             "title": "Selecione as informações",
@@ -332,6 +376,7 @@ export default {
     },
     "terms": {
         "title": "TERMOS DE USO",
-        "text": termsPT
+        "text": termsPT,
+        "close": "Fechar"
     }
 }

--- a/src/views/pages/dashboard/keywords.vue
+++ b/src/views/pages/dashboard/keywords.vue
@@ -18,7 +18,7 @@
                 </div>
 
                 <div class="form-group col-md-12">
-                  <a class="btn btn-dark styleBtn" @click="Upload()">Submit</a>
+                  <a class="btn btn-dark styleBtn" @click="Upload()">{{ $t('dashboard.keywords.submit') }}</a>
                 </div>
               </div>
             </form>

--- a/src/views/pages/dashboard/profile.vue
+++ b/src/views/pages/dashboard/profile.vue
@@ -4,13 +4,13 @@
     <div class="col-sm-8">
       <div class="card styleCard">
         <div class="card-body">
-          <h5 class="card-title" style="text-align: center"><h3>Profile</h3></h5>
+          <h5 class="card-title" style="text-align: center"><h3>{{ $t('dashboard.profile.profile') }}</h3></h5>
           <div class="card-text">
             <form>
               <div class="form-row">
                 <div class="form-group col-md-4 text-center">
-                  <p class="text-left">Profile Picture
-                    <p-popover-labels text="Foto para o perfil" /></p>
+                  <p class="text-left">{{ $t('dashboard.profile.profilePicture') }}
+                    <p-popover-labels :text="$t('dashboard.profile.profilePictureMessage')" /></p>
                   <md-avatar class="md-avatar-icon stylePicture">
                     <div class="logo">
                       <img :src="imagePerson" />
@@ -18,22 +18,22 @@
                   </md-avatar>
                   <br>
                   <br>
-                  <a class="btn btn-primary" style="color: #ffffff; background-color: #ff6107; border-color: #ff6107" @click="UploadPicture()">Upload new picture</a>
+                  <a class="btn btn-primary" style="color: #ffffff; background-color: #ff6107; border-color: #ff6107" @click="UploadPicture()">{{ $t('dashboard.profile.uploadNewPicture') }}</a>
                 </div>
                 <div class="form-group col-md-7">
                   <div class="form-group">
                   <label for="inputName">{{ $t('dashboard.keywords.name') }}</label>&nbsp;
-                    <p-popover-labels text="Nome social" />
+                    <p-popover-labels :text="$t('dashboard.profile.usernameMessage')" />
                     <input class="form-control"  v-model="user.name" id="inputName">
                   </div>
                   <div class="form-group">
                     <label>{{ $t('register.lbEmail') }}</label>
-                    <p-popover-labels text="Não é possível modificar o e-mail" />
+                    <p-popover-labels :text="$t('dashboard.profile.emailMessage')" />
                     <input type="email" v-model="user.email" class="form-control" disabled>
                   </div>
                   <div class="form-group">
-                    <label>User Name</label>
-                    <p-popover-labels text="Nome de usuário" />
+                    <label>{{ $t('register.lbUsername') }}</label>
+                    <p-popover-labels :text="$t('register.lbUsername')" />
                     <input v-model="user.username" class="form-control">
                   </div>
 
@@ -44,7 +44,7 @@
                 </div>
                 <div class="form-group col-md-11">
                   <div class="text-right align-self-end"><br>
-                    <a  class="btn btn-primary" style="color: #ffffff; background-color: #ff6107; border-color: #ff6107" @click="submitInfo()">Submit</a>
+                    <a  class="btn btn-primary" style="color: #ffffff; background-color: #ff6107; border-color: #ff6107" @click="submitInfo()">{{ $t('register.submit') }}</a>
                   </div>
                 </div>
               </div>

--- a/src/views/pages/login.vue
+++ b/src/views/pages/login.vue
@@ -7,7 +7,7 @@
 
             <div class="card-body">
 
-                <h5 class="mb-0">Acesse sua conta</h5>
+                <h5 class="mb-0">{{ $t('login.loginAccount') }}</h5>
                 <br><br>
                 <form class="form-signin" @submit.prevent="loginSubmit">
                     <div class="form-label-group">
@@ -28,7 +28,7 @@
                         <div class="col-6 link-social">
                           <md-list-item class="btn btn-danger style-google" @click="loginSocial('google')">
                             <md-icon>add_box</md-icon>
-                            <span class="md-list-item-text"> Acesso com o Google+</span>
+                            <span class="md-list-item-text">{{ $t('login.loginGoogle') }}</span>
                           </md-list-item>
                         </div>
                     </div>


### PR DESCRIPTION
## ✅  Descrição
Este PR tem como objetivo adicionar traduções de alguns campos que não possuem no Pauliceia atualmente. Foi percebido pelo grupo que alguns campos nas telas do Pauliceia, quando o idioma era trocado de português para inglês ou vice-versa, não possuíam tradução, em que algumas vezes eram escritos em português ou inglês. Assim, o grupo selecionou as telas que possuíam menos traduções e adicionou elas nas telas.

Um vídeo com a demonstração da funcionalidade e explicações técnicas pode ser encontrado [aqui](https://drive.google.com/file/d/1AyXzAGCLKBcDS9dhImavcW_GjsXiV-M0/view?usp=sharing)

## ⚙️ Modificações 
Dentre as adições e alterações feitas pelo grupo, as principais são:
-Na classe Terms.vue foi colocada a tradução em português e inglês do botão Close.
-Na classe ModalNotification.vue foi colocada a tradução em português e inglês dos campos: Comments, Notification, Submit, Responder, Denunciar, Excluir e Close.
-Na classe Notifications.vue foi colocada a tradução em português e inglês dos campos: General, Submit, Responder, Denunciar, Excluir, Personal,  Comments, Denunciation, of your message on layer, of your layer, of your message on your global notification, Comment on your layer, Reply of your message, on your layer,  on your global notification, Following e Notification.
-Na classe BoxNotification.vue foi colocada a tradução em português e inglês do campo Notification.
-Na classe LayersItemOther.vue foi colocada a tradução em português e inglês dos campos: Modelo Digital de Elevação de São Paulo (colorido) e Modelo Digital de Elevação de São Paulo (tons de cinza).
-Na classe keywords.vue foi colocada a tradução em português e inglês do campo Submit.
-Na classe profile.vue foi colocada a tradução em português e inglês dos campos: Profile, Profile Picture, Foto para o perfil, Upload new Picture, Nome Social, Não é possível modificar o e-mail, User name, Nome de usuário e Submit.
-Na classe login.vue foi colocada a tradução em português e inglês dos campos: Acesse sua conta, Acesso com o Google+.
-Para que esses campos tenham tradução quando o idioma do site mudar, também foi adicionada a tradução deles nos arquivos english.js e portuguese.js

## 📈 Resultado
- Como foram muitas páginas modificadas, o preview será da principal que foi modificada, que no caso foi a tela de Meu Perfil, em que a maior parte dos campos não possuíam tradução e havia uma mistura de inglês e português.
- Versão em português do Meu Perfil:
![image](https://github.com/pauliceia/pauliceia/assets/80797517/fbdcbff0-d3cc-4c8f-91ea-73cdba3d5757)
-Versão em inglês do Meu Perfil:
![image](https://github.com/pauliceia/pauliceia/assets/80797517/0aacbb37-49b3-46b8-959f-646d1be44365)

## 🧠 Como Testar 
Para realizar os testes integrados dentro do Pauliceia foi usada a ferramenta de Javascript chamada Playwright. No entanto, uma barreira que o grupo encontrou para fazê-lo rodar é que a versão do Node.js usada pelo Pauliceia é antiga (8.17.0), em que o Playwright somente funciona nas mais recentes. Dessa forma, foi necessário baixar o nvm, uma biblioteca do Node que permite a instalação e utilização de duas ou mais versões do node na mesma máquina.
[Windows] (https://github.com/coreybutler/nvm-windows) 
[Mac / Linux] (https://github.com/nvm-sh/nvm?tab=readme-ov-file#installing-and-updating 

Depois de baixadas as duas versões necessárias para rodar o Playwright (21.4.0) e o Pauliceia (8.17.0), a equipe utilizou dois terminais diferentes para rodar os testes, o passo a passo de cada um se encontra abaixo.

Rodar o Pauliceia localmente:
-Ir na pasta que se encontra o repositório do Pauliceia
-executar `nvm use 8.17.0`
-executar `npm run dev` 

Em outro terminal executar a ferramenta de teste Playwright
-Ir na pasta que se encontra o repositório do Pauliceia
-executar `nvm use 21.4.0`
-executar `npx playwright test --ui` 

Uma interface semelhante a seguinte deve abrir permitindo a execução dos testes: 

![image](https://github.com/pauliceia/pauliceia/assets/80797517/81fd158b-25eb-43fd-8f47-ae0c84c5e075)

